### PR TITLE
Resource file should be in expected location.

### DIFF
--- a/server/RevShop/pom.xml
+++ b/server/RevShop/pom.xml
@@ -124,10 +124,5 @@
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
 		</plugins>
-		<resources>
-			<resource>
-				<directory>src/resources</directory>
-			</resource>
-		</resources>
 	</build>
 </project>


### PR DESCRIPTION
We need the resources file in 
`main/resources/application.properties` and also in 
`test/resources/application.properties`

These are standard locations recommended by the Framework. We benefit from using them unless there is a reason to go custom.

This pull request removes the custom config in the pom.xml so the framework can find the resources files in the default location.